### PR TITLE
Add cst-dependencies rep to maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,12 @@ repositories {
         url "https://github.com/rosjava/rosjava_mvn_repo/raw/master"
     }
     maven {
-        url "https://artifacts.camunda.com/artifactory/public/"
+        url "https://artifacts.camunda.com/ui/native/public/"
     }
     maven { url 'https://jitpack.io' }
+    maven {
+            url 'https://cst-group.github.io/cst-dependencies/maven-repo/'
+        }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,6 @@ repositories {
     maven {
         url "https://github.com/rosjava/rosjava_mvn_repo/raw/master"
     }
-    maven {
-        url "https://artifacts.camunda.com/ui/native/public/"
-    }
     maven { url 'https://jitpack.io' }
     maven {
             url 'https://cst-group.github.io/cst-dependencies/maven-repo/'


### PR DESCRIPTION
Due to https://spring.io/blog/2024/12/02/repository-springsource-com-sunset some of the dependencies were missing so we added the libs to https://github.com/CST-Group/cst-dependencies